### PR TITLE
cre2.h: include the header only once

### DIFF
--- a/src/cre2.h
+++ b/src/cre2.h
@@ -18,6 +18,8 @@
 extern "C" {
 #endif
 
+#pragma once
+
 #ifndef cre2_decl
 #  define cre2_decl	extern
 #endif


### PR DESCRIPTION
It was causing symbol conflicts in my environment when it didn't have include guards or a `#pragma once`.