### PR TITLE
Use Fixed Sized Integer for for Ranges

### DIFF
--- a/src/cre2.h
+++ b/src/cre2.h
@@ -140,8 +140,8 @@ typedef enum cre2_anchor_t {
 } cre2_anchor_t;
 
 typedef struct cre2_range_t {
-  long	start;	/* inclusive start index for bytevector */
-  long	past;	/* exclusive end index for bytevector */
+  int64_t	start;	/* inclusive start index for bytevector */
+  int64_t	past;	/* exclusive end index for bytevector */
 } cre2_range_t;
 
 cre2_decl int cre2_match	(const cre2_regexp_t * re,


### PR DESCRIPTION
The `long` type varies size on different platforms. On Windows it is
32 bits but on macOS and Linux it is 64. This switches to a fixed-size
type so that bindings from other langauages can predict the size of
the range structure.