### PR TITLE
Add stdint headers

### DIFF
--- a/src/cre2.h
+++ b/src/cre2.h
@@ -21,6 +21,8 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
+
 #ifndef cre2_decl
 #  define cre2_decl	extern
 #endif


### PR DESCRIPTION
This should enable support for various integer types like `int64_t` on certain systems.

I hope I put it in the correct position @marcomaggi. Let me know, I can also edit that.

Closes #19.