### PR TITLE
Return all named groups when iterating

### DIFF
--- a/src/cre2.cpp
+++ b/src/cre2.cpp
@@ -216,7 +216,7 @@ cre2_program_size (const cre2_regexp_t *re)
 struct cre2_named_groups_iter_t
 {
   const RE2 * re;
-  std::map<std::string, int>::const_iterator it;
+  std::map<int, std::string>::const_iterator it;
 };
 
 cre2_named_groups_iter_t *
@@ -224,19 +224,19 @@ cre2_named_groups_iter_new(const cre2_regexp_t *re)
 {
   cre2_named_groups_iter_t * iter = new (std::nothrow)cre2_named_groups_iter_t;
   iter->re = TO_CONST_RE2(re);
-  iter->it = iter->re->NamedCapturingGroups().begin();
+  iter->it = iter->re->CapturingGroupNames().begin();
   return iter;
 }
 bool
 cre2_named_groups_iter_next(cre2_named_groups_iter_t* iter, const char ** name, int *index)
 {
-  if (iter->it == iter->re->NamedCapturingGroups().end()) {
+  if (iter->it == iter->re->CapturingGroupNames().end()) {
     *name = NULL;
     *index = -1;
     return false;
   } else {
-    *index = iter->it->second;
-    *name = iter->it->first.c_str();
+    *index = iter->it->first;
+    *name = iter->it->second.c_str();
     ++iter->it;
     return true;
   }


### PR DESCRIPTION
Currently, when the same name is declared multiple times, the iterator will only return one of them. This doesn't seem to be the intent of a named group iterator, so instead we use the int->string map which contains all groups.

This should be a compatible change because the `struct cre2_named_groups_iter` is not exported.