### PR TITLE
Change return type of cre2_set_compile from int to bool

### DIFF
--- a/src/cre2.cpp
+++ b/src/cre2.cpp
@@ -718,11 +718,11 @@ cre2_set_add_simple(cre2_set *set, const char *pattern)
 
 
 // Compile the regex set into a DFA. Must be called after add and before match.
-int
+bool
 cre2_set_compile(cre2_set *set)
 {
   RE2::Set *s = TO_RE2_SET(set);
-  return static_cast<int>(s->Compile());
+  return s->Compile();
 }
 
 // Match the set of regex against text and store indices of matching regexes in match array.


### PR DESCRIPTION
The inner implementation RE2::Set::Compile() will return true for success and false for failure of prog_ compilation. 
The cast int type will confuse developers to use the null prog_ without checking the returned status and then cause crash.

This commit changes the return type of cre2_set_compile from `int` to `bool`.

fixes: #27

Signed-off-by: hopper-vul <hopper.vul@gmail.com>