### PR TITLE
Change return type of cre2_set_compile from int to bool

### DIFF
--- a/src/cre2.cpp
+++ b/src/cre2.cpp
@@ -718,11 +718,11 @@ cre2_set_add_simple(cre2_set *set, const char *pattern)
 
 
 // Compile the regex set into a DFA. Must be called after add and before match.
-int
+bool
 cre2_set_compile(cre2_set *set)
 {
   RE2::Set *s = TO_RE2_SET(set);
-  return static_cast<int>(s->Compile());
+  return s->Compile();
 }
 
 // Match the set of regex against text and store indices of matching regexes in match array.

--- a/src/cre2.h
+++ b/src/cre2.h
@@ -330,8 +330,8 @@ cre2_decl int cre2_set_add(cre2_set *set, const char *pattern, size_t pattern_le
 cre2_decl int cre2_set_add_simple(cre2_set *set, const char *pattern);
 
 /* Compile the regex set into a DFA. Must be called after add and before match.
- * Returns 1 on success, 0 on error */
-cre2_decl int cre2_set_compile(cre2_set *set);
+ * Returns true on success, false on error */
+cre2_decl bool cre2_set_compile(cre2_set *set);
 
 /* Match the set of regex against text and store indices of matching regexes in match array.
  * Returns the number of regexes which match. */


### PR DESCRIPTION
The inner implementation RE2::Set::Compile() will return true for success and false for failure of prog_ compilation. 
Other APIs return -1 to inform an error, however this API use 0.
The cast int type will confuse developers to use the null prog_ without properly checking the returned status and then cause crash.

fixes: #27 

Signed-off-by: hopper-vul <hopper.vul@gmail.com>