### PR TITLE
add missing cstring include

### DIFF
--- a/src/cre2.cpp
+++ b/src/cre2.cpp
@@ -18,6 +18,7 @@
 
 #include <cstdlib>
 #include <cstdio>
+#include <cstring>
 #include <vector>
 
 


### PR DESCRIPTION
fails on newer compilers/toolchains without